### PR TITLE
Change sed path

### DIFF
--- a/share/ghu/ghu-parse
+++ b/share/ghu/ghu-parse
@@ -1,4 +1,4 @@
-#!/bin/sed -f
+#!/usr/bin/env sed -f
 #
 # pbrisbin 2014
 #


### PR DESCRIPTION
`/bin/sed` doesn't exist on OS X. Will this work for Arch as well?
