### PR TITLE
Use mkdir -p rather than install -D

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ test:
 	cram test
 
 install:
-	install -D -m755 bin/ghu $(DESTDIR)$(PREFIX)/bin/ghu
-	install -D -m755 share/ghu/parse-header $(DESTDIR)$(PREFIX)/share/ghu/parse-header
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/share/ghu
+	install -m755 bin/ghu $(DESTDIR)$(PREFIX)/bin/ghu
+	install -m755 share/ghu/parse-header $(DESTDIR)$(PREFIX)/share/ghu/parse-header
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/ghu \


### PR DESCRIPTION
The install binary on OSX does not support -D, so this is potentially more
portable (and worked on my mac).

Resolves #2
